### PR TITLE
Added array-type

### DIFF
--- a/src/rules/typescript.ts
+++ b/src/rules/typescript.ts
@@ -10,8 +10,8 @@ export = {
   "@typescript-eslint/array-type": [
     "error",
     {
-      default: "array",
-      readonly: "array"
+      default: "array-simple",
+      readonly: "array-simple"
     }
   ]
 };

--- a/src/rules/typescript.ts
+++ b/src/rules/typescript.ts
@@ -6,5 +6,12 @@ export = {
   "@typescript-eslint/no-use-before-define": [ "off" ],
   "@typescript-eslint/no-unused-vars": [ "warn", { argsIgnorePattern: "^_" } ],
   "@typescript-eslint/camelcase": [ "off" ],
-  "@typescript-eslint/no-empty-function": [ "warn" ]
+  "@typescript-eslint/no-empty-function": [ "warn" ],
+  "@typescript-eslint/array-type": [
+    "error",
+    {
+      default: "array",
+      readonly: "array"
+    }
+  ]
 };


### PR DESCRIPTION
> Use T[] or readonly T[] for simple types (i.e. types which are just primitive names or type references). Use Array<T> or ReadonlyArray<T> for all other types (union types, intersection types, object types, function types, etc).

**Incorrect ❌  code for "array-simple":**
```typescript
const a: (string | number)[] = ['a', 'b'];
const b: { prop: string }[] = [{ prop: 'a' }];
const c: (() => void)[] = [() => {}];
const d: Array<MyType> = ['a', 'b'];
const e: Array<string> = ['a', 'b'];
const f: ReadonlyArray<string> = ['a', 'b'];
```
**Correct ✅  code for "array-simple":**
```typescript
const a: Array<string | number> = ['a', 'b'];
const b: Array<{ prop: string }> = [{ prop: 'a' }];
const c: Array<() => void> = [() => {}];
const d: MyType[] = ['a', 'b'];
const e: string[] = ['a', 'b'];
const f: readonly string[] = ['a', 'b'];
```

This makes it so complex typings are converted (`Array<string | number>`) and simple ones should be defined in a simple way as above describes (`string[]`).