### PR TITLE
Added key-spacing rule

### DIFF
--- a/src/rules/eslint.ts
+++ b/src/rules/eslint.ts
@@ -159,6 +159,13 @@ export = {
       }
     }
   ],
+  "key-spacing": [
+    "error",
+    {
+      beforeColon: false,
+      afterColon: true
+    }
+  ],
   // "newline-per-chained-call": [ "error", { ignoreChainWithDepth: 2 } ],
   "dot-location": [ "error", "property" ],
   "comma-style": [ "error", "last" ],


### PR DESCRIPTION
### Added key-spacing rule.

**Incorrect ❌  "key-spacing":**

```typescript
const t = {
  x: 0,
  y:0
};
```

**Correct ✅  "key-spacing":**

```typescript
const t = {
  x: 0,
  y: 0
};