### PR TITLE
Fixed JS .json file linting issue

### DIFF
--- a/src/configs/eslint-recommended.ts
+++ b/src/configs/eslint-recommended.ts
@@ -1,8 +1,9 @@
 import eslintRules from "../rules/eslint";
+import javascriptTypescriptOverrides from "../overrides/javascript-typescript";
 import jsonEslintOverrides from "../overrides/json-eslint";
 
 export = {
   extends: [ "./configs/eslint" ],
   rules: eslintRules,
-  overrides: [ ...jsonEslintOverrides ]
+  overrides: [ ...javascriptTypescriptOverrides, ...jsonEslintOverrides ]
 };


### PR DESCRIPTION
Added JSON Eslint override rules to `eslint-recommended` config