### PR TITLE
Add `rel="noreferrer"` rule

### DIFF
--- a/src/rules/react.ts
+++ b/src/rules/react.ts
@@ -70,6 +70,14 @@ export = {
       prop: "parens-new-line"
     }
   ],
+  "react/jsx-no-target-blank": [
+    "error",
+    {
+      allowReferrer: true,
+      enforceDynamicLinks: "always",
+      warnOnSpreadAttributes: true
+    }
+  ],
   "react-hooks/rules-of-hooks": [ "error" ],
   "react-hooks/exhaustive-deps": [ "error" ]
 };


### PR DESCRIPTION
Added rule to automatically add `rel="noreferrer"` to `<a>` tags that have `target="_blank"` to increase security.

The rule will allow `rel="noopener"`, `rel="noreferrer"` and `rel="noopener noreferrer"`, however, it will error if none are given. `eslint --fix` will automatically add `rel="noreferrer"` if an `<a>` tag has `target="_blank"`.

References:

- ["noreferrer" reference](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer)
- [How to fix target=”_blank” links: a security and performance issue in web pages](https://medium.com/sedeo/how-to-fix-target-blank-a-security-and-performance-issue-in-web-pages-2118eba1ce2f)