### PR TITLE
Added `@typescript-eslint/naming-convention` directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gravitywelluk/eslint-plugin",
   "description": "Gravitywell defined ESLint rule sets as an ESLint plugin",
-  "version": "1.0.38",
+  "version": "2.0.0",
   "keywords": [
     "gravitywell",
     "gravitywelluk",

--- a/src/rules/typescript.ts
+++ b/src/rules/typescript.ts
@@ -26,5 +26,16 @@ export = {
       default: "array-simple",
       readonly: "array-simple"
     }
+  ],
+  "@typescript-eslint/naming-convention": [
+    "error",
+    {
+      selector: "typeLike",
+      format: [ "PascalCase" ]
+    },
+    {
+      selector: "enumMember",
+      format: [ "UPPER_CASE", "PascalCase" ]
+    }
   ]
 };


### PR DESCRIPTION
Added` @typescript-eslint/naming-convention` directives

### `typeLike` (`class`, `interface`, `typeAlias`, `enum`, `typeParameter`)
**Incorrect `typeLike` ❌**

```typescript
type sideBarProps = BoxProps;

interface sideBarProps {
  color: string;
}
```

**Correct `typeLike` ✅**

```typescript
type SideBarProps = BoxProps;

interface SideBarProps {
  color: string;
}
```

### `enumMember`

**Incorrect `enumMember` ❌**

```typescript
export enum EmploymentStatus {
  worker = "worker",
  employee = "employee",
  self-employed = "self employed",
  notEmployed = "not employed"
}
```

**Correct `typeLike` ✅**

```typescript
export enum EmploymentStatus {
  WORKER = "worker",
  EMPLOYEE = "employee",
  SELF_EMPLOYED = "self employed",
  NOT_EMPLOYED = "not employed"
}

export enum EmploymentStatus {
  Worker = "worker",
  Employee = "employee",
  SelfEmployed = "self employed",
  NotEmployed = "not employed"
}
```
